### PR TITLE
Updrade tailwindcss to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "autoprefixer": "^9.5.1",
-    "tailwindcss": "^1.0"
+    "tailwindcss": "^1.2.0"
   },
   "devDependencies": {
     "@fullhuman/postcss-purgecss": "^1.2.0",

--- a/public/tailwind.css
+++ b/public/tailwind.css
@@ -3,10 +3,6 @@
 @tailwind utilities;
 
 
-.transition {
-  transition: .2s ease;
-}
-
 .sr-only {
   position: absolute !important; /* Outside the DOM flow */
   height: 1px; width: 1px; /* Nearly collapsed */
@@ -29,7 +25,7 @@
 }
 
 .input:focus {
-  @apply shadow outline-none border-gray-400 transition;
+  @apply shadow outline-none border-gray-400 duration-200 ease-linear;
 
   box-shadow: 0 0 0 0.2rem theme("colors.gray.200");
   background-clip: padding-box;


### PR DESCRIPTION
This is the fix for following error
```
[0] CssSyntaxError: /home/jibingeo/tailwind-airbnb/public/tailwind.css:32:3: `@apply` cannot be used with .transition because .transition is included in multiple rulesets.
[0]
[0]   30 |
[0]   31 | .input:focus {
[0] > 32 |   @apply shadow outline-none border-gray-400 transition;
[0]      |   ^
[0]   33 |
[0]   34 |   box-shadow: 0 0 0 0.2rem theme("colors.gray.200");
```

Latest tailwindcss@1.2 comes with [CSS Transitions support](https://tailwindcss.com/docs/release-notes/#tailwind-css-v1-2). 
